### PR TITLE
Upgrade to Alpine 3.18

### DIFF
--- a/repos/jekyll/Dockerfile
+++ b/repos/jekyll/Dockerfile
@@ -115,6 +115,15 @@ RUN apk --no-cache add \
   yarn
 
 #
+# Alpine 3.15 is not supported by sass-embedded. Please upgrade to Alpine 3.18
+# See <https://github.com/jekyll/jekyll/issues/9381#issuecomment-1585493647>
+# How to upgrade alpine docker base images for security patches
+# See <https://stackoverflow.com/a/75407593/2477854>
+#
+
+RUN apk update && apk upgrade
+
+#
 # Gems
 # Update
 #


### PR DESCRIPTION
Alpine 3.15 is not supported by sass-embedded. Please upgrade to Alpine 3.18 See <https://github.com/jekyll/jekyll/issues/9381#issuecomment-1585493647>

How to upgrade alpine docker base images for security patches See <https://stackoverflow.com/a/75407593/2477854>

# Pull Request Check List

Resolves: #issue-number-here

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our CONTRIBUTING.md guide at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
