### PR TITLE
Allow caching of additional gems

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ export JEKYLL_VERSION=4.3.3
 docker run --rm \
   --volume="$PWD:/srv/jekyll:Z" \
   --volume="$PWD/vendor/bundle:/usr/local/bundle:Z" \
+  --volume="$PWD/vendor/gem:/opt/gem:Z" \
   -it jvconseil/jekyll:$JEKYLL_VERSION \
   jekyll build
 ```

--- a/repos/jekyll-docker/Dockerfile
+++ b/repos/jekyll-docker/Dockerfile
@@ -187,6 +187,8 @@ RUN mkdir -p /usr/gem/cache/bundle
 RUN chown -R jekyll:jekyll \
   /usr/gem/cache/bundle
 
+RUN mkdir -p /opt/gem && chown jekyll:jekyll /opt/gem
+
 CMD ["jekyll", "--help"]
 ENTRYPOINT ["/usr/jekyll/bin/entrypoint"]
 WORKDIR /srv/jekyll

--- a/repos/jekyll-docker/copy/all/usr/jekyll/bin/entrypoint
+++ b/repos/jekyll-docker/copy/all/usr/jekyll/bin/entrypoint
@@ -44,4 +44,7 @@ if [ "$JEKYLL_ROOTLESS" ]; then
   groupmod -o -g $JEKYLL_GID jekyll
 fi
 
+export GEM_PATH=$(gem env path)
+export GEM_HOME=/opt/gem
+
 exec "$@"


### PR DESCRIPTION
# Background and Suggested Fix

Somehow the caching as described in the README.md file didn't work for me. It might be, because I need additional gems for my Jekyll builds, but I don't exactly know. The changes in this commit seem to fix the problem.

- The changes in the Dockerfile create a new directory for gems that someone might want to install additionally (optionally) to the ones that are already installed in the container image.
- The changes in the entrypoint file do two things:
  - The export `GEM_PATH`. This is done to keep `/usr/gem` in the list of directories that ruby looks for gems. So far ruby only looks in `/usr/gem` for gems, because `GEM_HOME` points to that directory. But because I want to overwrite `GEM_HOME` with `/opt/gem` the `/usr/gem` directory has to be explicitly saved in `GEM_PATH`.
  - Overwrite the `GEM_HOME` environment variable. This way ruby looks for gems in `/opt/gem`.
- The changes in README.md instruct the user of the image to mount a lokal directory on the host into the `/opt/gem` directory in the container. This way, additionally installed gems are stored persistently on the host and can be used in subsequent containers that are started from the container image.

# Missing Tests Build

Unfortunately, I couldn't build the new image locally on my machine. It must have to do with the opts.yml files. But I have had this problem a long time (already with the images built by envygeeks). To fix this, I used the suggested changes in the pull request to build my one image on top of the images from envygeeks. And that worked.